### PR TITLE
Enhancement to the CLI-first workflow

### DIFF
--- a/context/memory.md
+++ b/context/memory.md
@@ -157,11 +157,12 @@ fig.show()
 ```
 
 ## Release Status
-- **Current Version**: 0.1.0 (Published to PyPI)
-- **Next Version**: 1.0.0 (Major version with breaking changes)
-- **Migration Status**: ✅ **COMPLETE** - Ready for v1.0.0 release
+- **Current Version**: 1.0.1 (Published to PyPI) ✅ **SUCCESSFUL HOTFIX RELEASE**
+- **Previous Versions**: 0.1.0, 1.0.0 (Published to PyPI)
+- **Migration Status**: ✅ **COMPLETE** - v1.0.1 verified working in fresh environment
 - **API Stability**: Production-ready with clean, unified interface
 - **Legacy Code**: ✅ **COMPLETELY ELIMINATED** - Zero legacy components remain
+- **Critical Fix**: v1.0.1 adds missing pydantic dependency (v1.0.0 had import error)
 
 ## Architecture Status
 - **Clean 3-Step Workflow**: Discovery → Configuration → Plotting

--- a/examples/demo_ota.ipynb
+++ b/examples/demo_ota.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -969,7 +969,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -1008,6 +1008,7 @@
        ],
        "layout": {
         "dragmode": "zoom",
+        "height": 600,
         "showlegend": true,
         "template": {
          "data": {
@@ -1790,6 +1791,7 @@
          "x": 0.5,
          "xanchor": "center"
         },
+        "width": 800,
         "xaxis": {
          "exponentformat": "SI",
          "fixedrange": false,
@@ -1861,8 +1863,8 @@
     "      Phase: \"tf_phase\"\n",
     "\n",
     "                                    \n",
-    "plot_height: 600\n",
-    "show_zoom_buttons: false\n",
+    "height: 600\n",
+    "width: 800\n",
     "show_rangeslider: true\n",
     "\"\"\")\n",
     "\n",

--- a/examples/demo_ota_ac.py
+++ b/examples/demo_ota_ac.py
@@ -1,0 +1,32 @@
+import wave_view as wv
+import numpy as np
+
+spice_file = "./raw_data/tb_ota_5t/test_ac/results.raw"
+
+data, metadata = wv.load_spice_raw(spice_file)
+
+data["tf_db"] = 20*np.log10(np.abs(data["v(out)"]))
+data["tf_phase"] = np.angle(data["v(out)"])/np.pi*180
+
+# Now proceed with plotting using YAML configuration
+spec = wv.PlotSpec.from_yaml("""
+title: "AC Analysis - Frequency Response"
+
+X:
+  signal: "frequency"
+  label: "Frequency (Hz)"
+  scale: "log"
+                                    
+Y:
+  - label: "Magnitude (dB)"
+    signals:
+      Magnitude: "tf_db"
+  - label: "Phase (deg)"
+    signals:
+      Phase: "tf_phase"        
+height: 600
+width: 800
+show_rangeslider: true
+""")
+
+fig2 = wv.plot(data, spec)

--- a/examples/plot_spec_ac.yaml
+++ b/examples/plot_spec_ac.yaml
@@ -1,0 +1,18 @@
+raw: "./raw_data/Ring_Oscillator_7stage.raw"
+
+title: "SPICE Simulation - Key Signals"
+
+X:
+  signal: "time"
+  label: "Time (s)"
+
+Y:
+  - label: "Key Voltages (V)"
+    signals:
+      VDD: "v(vdd)"
+      Bus01: "v(bus01)"
+      Bus02: "v(bus02)"
+      Bus03: "v(bus03)"
+
+height: 600
+show_rangeslider: true

--- a/src/wave_view/core/plotspec.py
+++ b/src/wave_view/core/plotspec.py
@@ -17,7 +17,8 @@ class XAxisSpec(BaseModel):
     """X-axis configuration specification."""
     signal: str = Field(..., description="X-axis signal key")
     label: Optional[str] = Field(None, description="X-axis label")
-    log_scale: bool = Field(False, description="Use logarithmic scale")
+    scale: Optional[str] = Field(None, description="Scale type: 'log' or 'linear' (intuitive syntax)")
+    log_scale: bool = Field(False, description="Use logarithmic scale (legacy syntax)")
     unit: Optional[str] = Field(None, description="Unit for display")
     range: Optional[List[float]] = Field(None, description="[min, max] range")
 
@@ -26,7 +27,8 @@ class YAxisSpec(BaseModel):
     """Y-axis configuration specification."""
     label: str = Field(..., description="Y-axis label")
     signals: Dict[str, str] = Field(..., description="Legend name -> signal key mapping")
-    log_scale: bool = Field(False, description="Use logarithmic scale")
+    scale: Optional[str] = Field(None, description="Scale type: 'log' or 'linear' (intuitive syntax)")
+    log_scale: bool = Field(False, description="Use logarithmic scale (legacy syntax)")
     unit: Optional[str] = Field(None, description="Unit for display")
     range: Optional[List[float]] = Field(None, description="[min, max] range")
     color: Optional[str] = Field(None, description="Axis color")
@@ -43,6 +45,7 @@ class PlotSpec(BaseModel):
     x: XAxisSpec = Field(..., description="X-axis configuration", alias="X")
     y: List[YAxisSpec] = Field(..., description="Y-axis specifications", alias="Y")
     title: Optional[str] = Field(None, description="Plot title")
+    raw: Optional[str] = Field(None, description="Path to SPICE raw file for self-contained specs")
     
     # Styling options
     width: Optional[int] = Field(None, description="Plot width in pixels")
@@ -111,9 +114,11 @@ class PlotSpec(BaseModel):
         """
         return {
             "title": self.title,
+            "raw": self.raw,
             "x": {
                 "signal": self.x.signal,
                 "label": self.x.label,
+                "scale": self.x.scale,
                 "log_scale": self.x.log_scale,
                 "unit": self.x.unit,
                 "range": self.x.range
@@ -122,6 +127,7 @@ class PlotSpec(BaseModel):
                 {
                     "label": y_spec.label,
                     "signals": y_spec.signals,
+                    "scale": y_spec.scale,
                     "log_scale": y_spec.log_scale,
                     "unit": y_spec.unit,
                     "range": y_spec.range,

--- a/src/wave_view/core/plotting.py
+++ b/src/wave_view/core/plotting.py
@@ -201,8 +201,8 @@ def _configure_x_axis(config: Dict[str, Any]) -> Dict[str, Any]:
         }
     }
     
-    # Add log scale support
-    if x_spec.get("log_scale", False):
+    # Add log scale support - support both intuitive and legacy syntax
+    if x_spec.get("scale") == "log" or x_spec.get("log_scale", False):
         x_axis_config["xaxis"]["type"] = "log"
     
     # Add range support
@@ -279,8 +279,8 @@ def _create_single_y_axis_config(
         "exponentformat": "SI"  # Use SI engineering notation for all Y-axes
     }
     
-    # Log scale support
-    if y_spec.get("log_scale", False):
+    # Log scale support - support both intuitive and legacy syntax
+    if y_spec.get("scale") == "log" or y_spec.get("log_scale", False):
         axis_config["type"] = "log"
     
     # Range support

--- a/tests/unit/cli/test_cli_raw_field.py
+++ b/tests/unit/cli/test_cli_raw_field.py
@@ -1,0 +1,160 @@
+"""
+Test CLI raw field functionality and override behavior.
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+from wave_view.cli import cli
+from wave_view.core.plotspec import PlotSpec
+
+
+class TestCliRawFieldHandling:
+    def test_plotspec_has_raw_field(self):
+        """Test that PlotSpec accepts and exports raw field."""
+        spec_dict = {
+            "title": "Test",
+            "raw": "test.raw",
+            "x": {"signal": "time"},
+            "y": [{"label": "V", "signals": {"V1": "v1"}}]
+        }
+        
+        spec = PlotSpec.model_validate(spec_dict)
+        assert spec.raw == "test.raw"
+        
+        # Test to_dict includes raw field
+        config = spec.to_dict()
+        assert config["raw"] == "test.raw"
+    
+    @patch('wave_view.cli.load_spice_raw')
+    @patch('wave_view.cli.create_plot')
+    @patch('wave_view.cli.configure_plotly_renderer')
+    def test_yaml_raw_field_usage(self, mock_configure, mock_plot, mock_load, tmp_path):
+        """Test using raw: field from YAML specification."""
+        # Create a test spec file with raw: field
+        spec_file = tmp_path / "spec.yaml"
+        raw_file = tmp_path / "test.raw"
+        raw_file.touch()  # Create empty file
+        
+        spec_content = f"""
+title: "Test Plot"
+raw: "{raw_file}"
+x:
+  signal: "time"
+y:
+  - label: "Voltage"
+    signals:
+      V1: "v1"
+"""
+        spec_file.write_text(spec_content)
+        
+        # Mock the load function to return fake data
+        mock_load.return_value = ({"time": [1, 2, 3], "v1": [1, 2, 3]}, {})
+        mock_plot.return_value = MagicMock()
+        
+        runner = CliRunner()
+        result = runner.invoke(cli, ['plot', str(spec_file)])
+        
+        assert result.exit_code == 0
+        assert f"Loading SPICE data from: {raw_file}" in result.output
+        mock_load.assert_called_once_with(raw_file)
+    
+    @patch('wave_view.cli.load_spice_raw')
+    @patch('wave_view.cli.create_plot')
+    @patch('wave_view.cli.configure_plotly_renderer')
+    def test_positional_override_with_warning(self, mock_configure, mock_plot, mock_load, tmp_path):
+        """Test positional argument overrides YAML raw: field with warning."""
+        spec_file = tmp_path / "spec.yaml"
+        yaml_raw_file = tmp_path / "yaml.raw"
+        cli_raw_file = tmp_path / "cli.raw"
+        yaml_raw_file.touch()
+        cli_raw_file.touch()
+        
+        spec_content = f"""
+title: "Test"
+raw: "{yaml_raw_file}"
+x:
+  signal: "time"
+y:
+  - label: "V"
+    signals:
+      V1: "v1"
+"""
+        spec_file.write_text(spec_content)
+        
+        mock_load.return_value = ({"time": [1, 2, 3], "v1": [1, 2, 3]}, {})
+        mock_plot.return_value = MagicMock()
+        
+        runner = CliRunner()
+        result = runner.invoke(cli, ['plot', str(spec_file), str(cli_raw_file)])
+        
+        assert result.exit_code == 0
+        assert "Warning:" in result.output
+        assert "CLI positional argument" in result.output
+        assert "overrides YAML raw: field" in result.output
+        assert f"Loading SPICE data from: {cli_raw_file}" in result.output
+        mock_load.assert_called_once_with(cli_raw_file)
+    
+    @patch('wave_view.cli.load_spice_raw')
+    @patch('wave_view.cli.create_plot')
+    @patch('wave_view.cli.configure_plotly_renderer')
+    def test_raw_option_override_with_warning(self, mock_configure, mock_plot, mock_load, tmp_path):
+        """Test --raw option overrides both positional and YAML with warning."""
+        spec_file = tmp_path / "spec.yaml"
+        yaml_raw_file = tmp_path / "yaml.raw"
+        pos_raw_file = tmp_path / "positional.raw"
+        opt_raw_file = tmp_path / "option.raw"
+        
+        for f in [yaml_raw_file, pos_raw_file, opt_raw_file]:
+            f.touch()
+        
+        spec_content = f"""
+title: "Test"
+raw: "{yaml_raw_file}"
+x:
+  signal: "time"
+y:
+  - label: "V"
+    signals:
+      V1: "v1"
+"""
+        spec_file.write_text(spec_content)
+        
+        mock_load.return_value = ({"time": [1, 2, 3], "v1": [1, 2, 3]}, {})
+        mock_plot.return_value = MagicMock()
+        
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            'plot', str(spec_file), str(pos_raw_file), 
+            '--raw', str(opt_raw_file)
+        ])
+        
+        assert result.exit_code == 0
+        assert "Warning:" in result.output
+        assert "CLI --raw option overrides" in result.output
+        assert f"Loading SPICE data from: {opt_raw_file}" in result.output
+        mock_load.assert_called_once_with(opt_raw_file)
+    
+    def test_no_raw_file_specified_error(self, tmp_path):
+        """Test error when no raw file is specified anywhere."""
+        spec_file = tmp_path / "spec.yaml"
+        spec_content = """
+title: "Test"
+x:
+  signal: "time"
+y:
+  - label: "V"
+    signals:
+      V1: "v1"
+"""
+        spec_file.write_text(spec_content)
+        
+        runner = CliRunner()
+        result = runner.invoke(cli, ['plot', str(spec_file)])
+        
+        assert result.exit_code == 1
+        assert "No raw file specified" in result.output
+        assert "--raw option:" in result.output
+        assert "Positional argument:" in result.output
+        assert "Add 'raw:" in result.output 

--- a/tests/unit/plotting/test_scale_syntax.py
+++ b/tests/unit/plotting/test_scale_syntax.py
@@ -1,0 +1,80 @@
+"""
+Test both intuitive and legacy scale syntax support.
+"""
+import pytest
+from src.wave_view.core.plotting import _configure_x_axis, _create_single_y_axis_config
+
+
+def test_x_axis_scale_log_syntax():
+    """Test that X-axis supports both scale: log and log_scale: true."""
+    # Test intuitive syntax: scale: "log"
+    config_intuitive = {"x": {"signal": "frequency", "scale": "log"}}
+    result = _configure_x_axis(config_intuitive)
+    assert result["xaxis"]["type"] == "log"
+    
+    # Test legacy syntax: log_scale: true
+    config_legacy = {"x": {"signal": "frequency", "log_scale": True}}
+    result = _configure_x_axis(config_legacy)
+    assert result["xaxis"]["type"] == "log"
+    
+    # Test that both together work (intuitive takes precedence)
+    config_both = {"x": {"signal": "frequency", "scale": "log", "log_scale": False}}
+    result = _configure_x_axis(config_both)
+    assert result["xaxis"]["type"] == "log"
+    
+    # Test linear scale
+    config_linear = {"x": {"signal": "frequency", "scale": "linear"}}
+    result = _configure_x_axis(config_linear)
+    assert "type" not in result["xaxis"] or result["xaxis"].get("type") != "log"
+
+
+def test_y_axis_scale_log_syntax():
+    """Test that Y-axis supports both scale: log and log_scale: true."""
+    # Test intuitive syntax: scale: "log"
+    y_spec_intuitive = {"label": "Voltage", "signals": {"V": "v(out)"}, "scale": "log"}
+    result = _create_single_y_axis_config(y_spec_intuitive, [0.0, 1.0], 0, {})
+    assert result["type"] == "log"
+    
+    # Test legacy syntax: log_scale: true
+    y_spec_legacy = {"label": "Voltage", "signals": {"V": "v(out)"}, "log_scale": True}
+    result = _create_single_y_axis_config(y_spec_legacy, [0.0, 1.0], 0, {})
+    assert result["type"] == "log"
+    
+    # Test that both together work (intuitive takes precedence)
+    y_spec_both = {"label": "Voltage", "signals": {"V": "v(out)"}, "scale": "log", "log_scale": False}
+    result = _create_single_y_axis_config(y_spec_both, [0.0, 1.0], 0, {})
+    assert result["type"] == "log"
+    
+    # Test linear scale
+    y_spec_linear = {"label": "Voltage", "signals": {"V": "v(out)"}, "scale": "linear"}
+    result = _create_single_y_axis_config(y_spec_linear, [0.0, 1.0], 0, {})
+    assert "type" not in result or result.get("type") != "log"
+
+
+def test_plotspec_scale_field():
+    """Test that PlotSpec can handle the scale field."""
+    from src.wave_view.core.plotspec import PlotSpec
+    
+    # Test X-axis with scale field
+    spec_dict = {
+        "title": "Test Plot",
+        "x": {"signal": "frequency", "scale": "log"},
+        "y": [{"label": "Voltage", "signals": {"V": "v(out)"}}]
+    }
+    
+    spec = PlotSpec.model_validate(spec_dict)
+    assert spec.x.scale == "log"
+    
+    # Test Y-axis with scale field
+    spec_dict = {
+        "title": "Test Plot", 
+        "x": {"signal": "frequency"},
+        "y": [{"label": "Voltage", "signals": {"V": "v(out)"}, "scale": "log"}]
+    }
+    
+    spec = PlotSpec.model_validate(spec_dict)
+    assert spec.y[0].scale == "log"
+    
+    # Test to_dict() includes scale field
+    config = spec.to_dict()
+    assert config["y"][0]["scale"] == "log" 


### PR DESCRIPTION
- Add raw: Optional[str] field to PlotSpec class
- Update CLI to make raw_file argument optional
- Support 3 ways to specify raw file (precedence order):
  1. --raw option (highest)
  2. Positional argument
  3. raw: field in YAML (lowest)
- Add warning messages when CLI overrides YAML
- Comprehensive error handling for missing raw file
- Update CLI help and examples
- Add 5 new tests covering all functionality
- Maintain backward compatibility with existing usage