### PR TITLE
docs: comprehensive yaml2plot v2.0.0 documentation update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pytest -v
 black src/ tests/
 
 # Check type hints with MyPy
-mypy src/wave_view
+mypy src/yaml2plot
 
 # Lint with flake8
 flake8 src/ tests/
@@ -209,13 +209,13 @@ Based on `.cursor/rules/development-guidelines.mdc`:
 
 ### Current Project Status
 
-**Version**: 1.1.1  
+**Version**: 2.0.0  
 **Architecture**: v1.0.0 modern API (fully implemented)  
 **Test Coverage**: 61 tests passing with good coverage  
-**Recent Branch**: `housekeeping-cleanup` (consolidated configurations and refactored PlotSpec.to_dict())
+**Recent Branch**: `docs-update-yaml2plot-v2` (PR #19 pending - documentation updates for v2.0.0)
 
 **Next Priorities** (check `context/todo.md` for current sprint):
-- Documentation updates for v1.1.0
+- Documentation updates for v2.0.0
 - Final testing and release preparation
 - Advanced features in backlog
 

--- a/src/yaml2plot/__init__.py
+++ b/src/yaml2plot/__init__.py
@@ -1,12 +1,12 @@
 """
-Wave View - SPICE Waveform Visualization Package
+yaml2plot - SPICE Waveform Visualization Package
 
 A Python package for visualizing SPICE simulation waveforms, designed primarily
 for Jupyter notebook integration with both simple plotting functions and advanced
 signal processing capabilities.
 """
 
-__version__ = "1.1.1"
+__version__ = "2.0.0"
 __author__ = "Jianxun Zhu"
 
 # Core classes
@@ -26,17 +26,17 @@ import plotly.io as pio
 
 def set_renderer(renderer: str = "auto"):
     """
-    Set the Plotly renderer for Wave View plots.
+    Set the Plotly renderer for yaml2plot plots.
 
     Args:
         renderer: Renderer type - "auto", "browser", "notebook", "plotly_mimetype", etc.
                  "auto" (default) detects environment automatically
 
     Example:
-        >>> import wave_view as wv
-        >>> wv.set_renderer("notebook")  # Force notebook inline display
-        >>> wv.set_renderer("browser")   # Force browser display
-        >>> wv.set_renderer("auto")      # Auto-detect (default)
+        >>> import yaml2plot as y2p
+        >>> y2p.set_renderer("notebook")  # Force notebook inline display
+        >>> y2p.set_renderer("browser")   # Force browser display
+        >>> y2p.set_renderer("auto")      # Auto-detect (default)
     """
     if renderer == "auto":
         configure_plotly_renderer()

--- a/src/yaml2plot/cli.py
+++ b/src/yaml2plot/cli.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 """
-Wave View CLI interface.
+yaml2plot CLI interface.
 
 Provides command-line interface for plotting SPICE waveforms using the v1.1.0 API.
 """

--- a/src/yaml2plot/core/__init__.py
+++ b/src/yaml2plot/core/__init__.py
@@ -1,1 +1,1 @@
-"""Core functionality for Wave View package."""
+"""Core functionality for yaml2plot package."""

--- a/src/yaml2plot/loader.py
+++ b/src/yaml2plot/loader.py
@@ -1,4 +1,4 @@
-"""SPICE raw-file loading helpers for Wave View.
+"""SPICE raw-file loading helpers for yaml2plot.
 
 These high-level functions build on `WaveDataset` to give users a quick way to
 obtain *(data_dict, metadata)* tuples either from a single SPICE *.raw* file or

--- a/src/yaml2plot/utils/__init__.py
+++ b/src/yaml2plot/utils/__init__.py
@@ -1,1 +1,1 @@
-"""Utility functions for Wave View package."""
+"""Utility functions for yaml2plot package."""

--- a/src/yaml2plot/utils/env.py
+++ b/src/yaml2plot/utils/env.py
@@ -1,4 +1,4 @@
-"""Environment / renderer helpers for Wave View.
+"""Environment / renderer helpers for yaml2plot.
 
 These utilities detect whether the code is running inside a Jupyter environment
 and configure Plotly's default renderer accordingly.


### PR DESCRIPTION
## Summary
• Complete documentation overhaul for yaml2plot v2.0.0 package rename
• Updates all .rst files, code examples, CLI references, and configuration
• Finalizes package references and version numbers for v2.0.0 release

## Changes
• **22 documentation files updated**: All .rst files with yaml2plot branding
• **Code examples**: All imports changed from `wave_view as wv` → `yaml2plot as y2p`  
• **CLI references**: All commands updated from `waveview` → `y2p`
• **Auto-generated docs**: Updated all _autosummary files for yaml2plot modules
• **Sphinx configuration**: Updated conf.py with v2.0.0 metadata and canonical URL
• **GitHub Actions**: Enhanced docs.yml workflow with build verification
• **Final cleanup**: Updated remaining package references and version numbers

## Test Plan
- [x] Documentation builds successfully with minimal warnings
- [x] All package references updated consistently
- [x] GitHub Pages deployment workflow ready
- [x] Version metadata correctly set to 2.0.0

🤖 Generated with [Claude Code](https://claude.ai/code)