### PR TITLE
T-009: deterministic loader coordinate inference and ambiguity warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ fig = y2p.plot(data, spec)
 fig.show()
 ```
 
+`load_spice_raw()` coordinate inference policy is deterministic:
+- Use `time` when present.
+- Else use `frequency` when present.
+- Else fall back to the first signal (dimension name: `axis`).
+- If both `time` and `frequency` exist, `time` is selected and a `UserWarning` is emitted.
+- If neither canonical coordinate exists, fallback is used and a `UserWarning` is emitted.
+
 **Advanced Example: Plotting Derived Signals**
 
 Because the API gives you direct access to the loaded data, you can easily perform calculations and plot the results.

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -24,7 +24,7 @@ T-008:
   pr: 28
   merged: true
 T-009:
-  status: review_in_progress
+  status: review_clean
   pr: 29
   merged: false
 T-010:

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -24,9 +24,9 @@ T-008:
   pr: 28
   merged: true
 T-009:
-  status: review_clean
+  status: done
   pr: 29
-  merged: false
+  merged: true
 T-010:
   status: ready
   pr: null

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -24,7 +24,7 @@ T-008:
   pr: 28
   merged: true
 T-009:
-  status: ready
+  status: in_progress
   pr: null
   merged: false
 T-010:

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -24,7 +24,7 @@ T-008:
   pr: 28
   merged: true
 T-009:
-  status: ready_for_review
+  status: review_in_progress
   pr: 29
   merged: false
 T-010:

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -24,8 +24,8 @@ T-008:
   pr: 28
   merged: true
 T-009:
-  status: in_progress
-  pr: null
+  status: ready_for_review
+  pr: 29
   merged: false
 T-010:
   status: ready

--- a/agents/scratchpads/T-009.md
+++ b/agents/scratchpads/T-009.md
@@ -1,0 +1,51 @@
+# T-009 Scratchpad
+
+## Task summary (DoD + verify)
+- Make x-axis coordinate inference deterministic and documented.
+- Add explicit handling/warnings for ambiguous coordinate choices.
+- Add tests for time/frequency/other-signal fallback scenarios.
+
+Verify:
+- `pytest tests/unit/loader -v`
+
+## Read (paths)
+- agents/context/lessons.md
+- agents/context/contract.md
+- agents/context/tasks.yaml
+- agents/context/tasks_state.yaml
+- agents/context/project_status.md
+- agents/roles/executor.md
+
+## Plan
+- [x] Lock in deterministic coordinate inference + ambiguity behavior with tests first.
+- [x] Implement minimal loader changes to satisfy tests.
+- [x] Update README/docs to document policy.
+- [x] Run required verification and record results.
+- [ ] Prepare closeout and status handoff for review.
+
+## Milestone notes
+- Intake complete.
+- Added loader unit tests for deterministic time/frequency priority, ambiguous canonical coordinate warning, and first-signal fallback warning.
+- Implemented deterministic coordinate selection policy in `load_spice_raw` with explicit `UserWarning` messages for ambiguous and fallback paths.
+- Updated README/API docs to document coordinate inference policy.
+
+## Patch summary
+- `src/yaml2plot/loader.py`: deterministic coordinate inference (`time` > `frequency` > first signal), explicit ambiguity/fallback warnings, and empty-signal guard.
+- `tests/unit/loader/test_loader_basic.py`: added coverage for time-vs-frequency ambiguity, frequency-only case, and non-canonical fallback case.
+- `README.md` and `docs/api.rst`: documented coordinate inference behavior and warning semantics.
+
+## PR URL
+- Pending.
+
+## Verification
+- `./venv/bin/python -m pytest -q tests/unit/loader/test_loader_basic.py -q` (pass)
+- `./venv/bin/python -m pytest tests/unit/loader -v` (pass: 25 passed)
+
+## Status request (Done / Blocked / In Progress)
+- In Progress.
+
+## Blockers / Questions
+- None.
+
+## Next steps
+- Implement tests and code for coordinate inference policy.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,20 @@ yaml2plot 2.0.1 exposes a streamlined, function-oriented public API built around
 
 This page documents each public symbol in the order you will use them.
 
+Coordinate Inference (`load_spice_raw`)
+----------------------------------------
+
+When building an ``xarray.Dataset`` from a SPICE ``.raw`` file, coordinate selection is deterministic:
+
+1. Use ``time`` if present.
+2. Otherwise use ``frequency`` if present.
+3. Otherwise use the first signal as a fallback coordinate (dimension name ``axis``).
+
+Warnings:
+
+* If both ``time`` and ``frequency`` are present, ``time`` is chosen and a ``UserWarning`` is emitted.
+* If neither canonical coordinate exists, the first-signal fallback is used and a ``UserWarning`` is emitted.
+
 Main API Symbols
 ----------------
 

--- a/src/yaml2plot/loader.py
+++ b/src/yaml2plot/loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+import warnings
 
 import numpy as np
 import xarray as xr
@@ -69,20 +70,42 @@ def load_spice_raw(raw_file: _PathLike) -> xr.Dataset:
     # Get all signals
     signals = wave_data.signals
     
-    # Find coordinate axis (time, frequency, or first signal)
+    # Find coordinate axis deterministically: time > frequency > first signal.
+    if not signals:
+        raise ValueError("SPICE raw file contains no signals")
+
     coord_signal = None
     dim_name = None
-    
-    if 'time' in [s.lower() for s in signals]:
-        coord_signal = next(s for s in signals if s.lower() == 'time')
-        dim_name = 'time'
-    elif 'frequency' in [s.lower() for s in signals]:
-        coord_signal = next(s for s in signals if s.lower() == 'frequency')
-        dim_name = 'frequency'
+
+    lower_signals = [s.lower() for s in signals]
+    has_time = "time" in lower_signals
+    has_frequency = "frequency" in lower_signals
+
+    if has_time and has_frequency:
+        coord_signal = next(s for s in signals if s.lower() == "time")
+        dim_name = "time"
+        warnings.warn(
+            "Ambiguous coordinate candidates found ('time' and 'frequency'); "
+            "using 'time' as x-axis coordinate.",
+            UserWarning,
+            stacklevel=2,
+        )
+    elif has_time:
+        coord_signal = next(s for s in signals if s.lower() == "time")
+        dim_name = "time"
+    elif has_frequency:
+        coord_signal = next(s for s in signals if s.lower() == "frequency")
+        dim_name = "frequency"
     else:
         # Fallback: use first signal as coordinate
         coord_signal = signals[0]
-        dim_name = 'axis'
+        dim_name = "axis"
+        warnings.warn(
+            f"Unable to infer canonical coordinate ('time' or 'frequency'); "
+            f"using first signal '{coord_signal}' as x-axis coordinate.",
+            UserWarning,
+            stacklevel=2,
+        )
     
     # Add coordinate
     coord_data = wave_data.get_signal(coord_signal)

--- a/tests/unit/loader/test_loader_basic.py
+++ b/tests/unit/loader/test_loader_basic.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+import warnings
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -154,6 +155,71 @@ class TestLoadSpiceRawXarray:
         # Check global attributes (metadata)
         assert ds.attrs["analysis_type"] == "transient"
         assert ds.attrs["corner"] == "tt"
+
+    def test_prefers_time_over_frequency_with_warning(self, tmp_path):
+        """When both canonical coordinates exist, choose time and warn."""
+        f = tmp_path / "test.raw"
+        f.write_text("dummy")
+
+        mock_ds = MagicMock()
+        mock_ds.signals = ["frequency", "time", "v(out)"]
+        mock_ds.metadata = {}
+        mock_ds.get_signal.side_effect = lambda name: {
+            "frequency": np.array([1e3, 1e4, 1e5]),
+            "time": np.array([0.0, 1e-9, 2e-9]),
+            "v(out)": np.array([0.1, 0.2, 0.3]),
+        }[name]
+
+        with patch.object(wv_loader.WaveDataset, "from_raw", return_value=mock_ds):
+            with pytest.warns(UserWarning, match="Ambiguous coordinate candidates"):
+                ds = wv_loader.load_spice_raw(f)
+
+        assert "time" in ds.coords
+        assert "frequency" in ds.data_vars
+        assert ds["frequency"].dims == ("time",)
+
+    def test_uses_frequency_when_time_absent_without_warning(self, tmp_path):
+        f = tmp_path / "test.raw"
+        f.write_text("dummy")
+
+        mock_ds = MagicMock()
+        mock_ds.signals = ["frequency", "gain"]
+        mock_ds.metadata = {}
+        mock_ds.get_signal.side_effect = lambda name: {
+            "frequency": np.array([1e3, 1e4, 1e5]),
+            "gain": np.array([10.0, 9.0, 8.0]),
+        }[name]
+
+        with patch.object(wv_loader.WaveDataset, "from_raw", return_value=mock_ds):
+            with warnings.catch_warnings(record=True) as record:
+                warnings.simplefilter("always")
+                ds = wv_loader.load_spice_raw(f)
+
+        assert len(record) == 0
+        assert "frequency" in ds.coords
+        assert "gain" in ds.data_vars
+        assert ds["gain"].dims == ("frequency",)
+
+    def test_fallbacks_to_first_signal_with_warning(self, tmp_path):
+        f = tmp_path / "test.raw"
+        f.write_text("dummy")
+
+        mock_ds = MagicMock()
+        mock_ds.signals = ["sweep", "v(out)", "v(in)"]
+        mock_ds.metadata = {}
+        mock_ds.get_signal.side_effect = lambda name: {
+            "sweep": np.array([0.0, 0.5, 1.0]),
+            "v(out)": np.array([0.1, 0.2, 0.3]),
+            "v(in)": np.array([1.8, 1.8, 1.8]),
+        }[name]
+
+        with patch.object(wv_loader.WaveDataset, "from_raw", return_value=mock_ds):
+            with pytest.warns(UserWarning, match="Unable to infer canonical coordinate"):
+                ds = wv_loader.load_spice_raw(f)
+
+        assert "axis" in ds.coords
+        np.testing.assert_array_equal(ds.coords["axis"].values, np.array([0.0, 0.5, 1.0]))
+        assert set(ds.data_vars) == {"v(out)", "v(in)"}
 
 
 class TestLoadCsvData:


### PR DESCRIPTION
## Summary
- make `load_spice_raw` coordinate inference deterministic (`time` > `frequency` > first signal)
- emit explicit `UserWarning` messages for ambiguous (`time` + `frequency`) and fallback coordinate selection
- add loader unit tests for time/frequency ambiguity, frequency-only path, and non-canonical fallback
- document the inference and warning policy in README and API docs

## Testing
- ./venv/bin/python -m pytest -q tests/unit/loader/test_loader_basic.py -q
- ./venv/bin/python -m pytest tests/unit/loader -v
