### PR TITLE
T-010: reduce import-time side effects and clarify CLI errors

### DIFF
--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -28,7 +28,7 @@ T-009:
   pr: 29
   merged: true
 T-010:
-  status: ready
+  status: in_progress
   pr: null
   merged: false
 T-011:

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -28,7 +28,7 @@ T-009:
   pr: 29
   merged: true
 T-010:
-  status: review_in_progress
+  status: request_changes
   pr: 30
   merged: false
 T-011:

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -28,8 +28,8 @@ T-009:
   pr: 29
   merged: true
 T-010:
-  status: in_progress
-  pr: null
+  status: ready_for_review
+  pr: 30
   merged: false
 T-011:
   status: ready

--- a/agents/context/tasks_state.yaml
+++ b/agents/context/tasks_state.yaml
@@ -28,7 +28,7 @@ T-009:
   pr: 29
   merged: true
 T-010:
-  status: ready_for_review
+  status: review_in_progress
   pr: 30
   merged: false
 T-011:

--- a/agents/scratchpads/T-010.md
+++ b/agents/scratchpads/T-010.md
@@ -1,0 +1,61 @@
+# T-010 Scratchpad
+
+## Task summary (DoD + verify)
+- DoD:
+  - Remove or minimize renderer configuration side effects during package import.
+  - Replace broad CLI exception handling with typed, actionable error paths.
+  - Keep user-facing CLI behavior stable for normal success cases.
+- Verify:
+  - `pytest tests/unit/cli -v`
+  - `pytest tests/workflows -k "cli or plot" -v`
+
+## Read (paths)
+- `agents/roles/executor.md`
+- `agents/context/lessons.md`
+- `agents/context/contract.md`
+- `agents/context/tasks.yaml`
+- `agents/context/tasks_state.yaml`
+- `agents/context/project_status.md`
+
+## Plan
+- Add/adjust tests to capture current import side effects and CLI error-path expectations.
+- Implement minimal code changes in `src/yaml2plot/__init__.py` and `src/yaml2plot/cli.py` to satisfy DoD.
+- Run required verification and document outputs.
+
+## Milestone notes
+- Intake complete; task moved to `in_progress`.
+- Added TDD coverage for import-time renderer side effects and CLI typed data-loading errors.
+- Replaced broad CLI exception handlers with typed `click.ClickException` paths.
+- Removed import-time Plotly renderer auto-configuration.
+
+## Patch summary
+- `src/yaml2plot/__init__.py`
+  - Removed automatic renderer configuration during module import.
+- `src/yaml2plot/cli.py`
+  - Reworked `plot` error handling into typed, actionable `click.ClickException` paths for spec loading, data normalization, plot creation, and save failures.
+  - Reworked `init` error handling to typed loader errors and explicit empty-signal failure.
+  - Reworked `signals` error handling to typed loader errors and explicit regex validation.
+- `tests/unit/test_package_metadata.py`
+  - Added regression test to assert import does not mutate `plotly.io.renderers.default`.
+- `tests/unit/cli/test_cli_basic.py`
+  - Added regression test asserting actionable `plot` data loading failure message.
+  - Updated signals loader-failure test to typed exception/assertion.
+
+## PR URL
+- Pending PR creation.
+
+## Verification
+- `./venv/bin/python -m pytest tests/unit/test_package_metadata.py tests/unit/cli/test_cli_basic.py -v`
+- `./venv/bin/python -m pytest tests/unit/cli -v`
+- `./venv/bin/python -m pytest tests/workflows -k "cli or plot" -v`
+- `./venv/bin/python scripts/lint_tasks_state.py`
+
+## Status request (Done / Blocked / In Progress)
+- In Progress
+
+## Blockers / Questions
+- `./venv/bin/pytest` has a broken shebang in this environment; used `./venv/bin/python -m pytest ...` instead.
+
+## Next steps
+- Push branch and open PR.
+- Update task state to `ready_for_review` with PR number and lint task state.

--- a/src/yaml2plot/__init__.py
+++ b/src/yaml2plot/__init__.py
@@ -65,11 +65,3 @@ __all__ = [
     "set_renderer",
     "pio",  # Give users access to plotly.io
 ]
-
-# Configure Plotly renderer automatically on import
-# This eliminates the need for manual renderer configuration in user code
-try:
-    configure_plotly_renderer()
-except Exception:
-    # If auto-detection fails, default to browser (safe fallback)
-    pio.renderers.default = "browser"

--- a/src/yaml2plot/cli.py
+++ b/src/yaml2plot/cli.py
@@ -106,85 +106,94 @@ def plot(
         y2p plot spec.yaml --title "My Analysis"     # Override title
     """
     plot.formatter_class = CustomFormatter
+    # Load the specification file
+    click.echo(f"Loading plot specification from: {spec_file}")
     try:
-        # Load the specification file
-        click.echo(f"Loading plot specification from: {spec_file}")
         spec = PlotSpec.from_file(spec_file)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except ValueError as exc:
+        raise click.ClickException(f"Invalid plot specification: {exc}") from exc
 
-        # Determine which raw file to use (precedence: --raw > positional > yaml raw: field)
-        final_raw_file = None
-        warning_msg = None
+    # Determine which raw file to use (precedence: --raw > positional > yaml raw: field)
+    final_raw_file = None
+    warning_msg = None
 
-        if raw_override:
-            # --raw option takes highest precedence
-            final_raw_file = raw_override
-            if raw_file or spec.raw:
-                warning_msg = f"CLI --raw option overrides "
-                if raw_file:
-                    warning_msg += f"positional argument '{raw_file}'"
-                if raw_file and spec.raw:
-                    warning_msg += f" and YAML raw: field '{spec.raw}'"
-                elif spec.raw:
-                    warning_msg += f"YAML raw: field '{spec.raw}'"
-        elif raw_file:
-            # Positional argument takes second precedence
-            final_raw_file = raw_file
-            if spec.raw:
-                warning_msg = f"CLI positional argument '{raw_file}' overrides YAML raw: field '{spec.raw}'"
-        elif spec.raw:
-            # YAML raw: field takes lowest precedence
-            final_raw_file = Path(spec.raw)
-        else:
-            # No raw file specified anywhere
-            raise click.ClickException(
-                "No raw file specified. Use one of:\n"
-                "  1. --raw option: y2p plot spec.yaml --raw sim.raw\n"
-                "  2. Positional argument: y2p plot spec.yaml sim.raw\n"
-                "  3. Add 'raw: sim.raw' to your YAML specification file"
-            )
+    if raw_override:
+        # --raw option takes highest precedence
+        final_raw_file = raw_override
+        if raw_file or spec.raw:
+            warning_msg = f"CLI --raw option overrides "
+            if raw_file:
+                warning_msg += f"positional argument '{raw_file}'"
+            if raw_file and spec.raw:
+                warning_msg += f" and YAML raw: field '{spec.raw}'"
+            elif spec.raw:
+                warning_msg += f"YAML raw: field '{spec.raw}'"
+    elif raw_file:
+        # Positional argument takes second precedence
+        final_raw_file = raw_file
+        if spec.raw:
+            warning_msg = f"CLI positional argument '{raw_file}' overrides YAML raw: field '{spec.raw}'"
+    elif spec.raw:
+        # YAML raw: field takes lowest precedence
+        final_raw_file = Path(spec.raw)
+    else:
+        # No raw file specified anywhere
+        raise click.ClickException(
+            "No raw file specified. Use one of:\n"
+            "  1. --raw option: y2p plot spec.yaml --raw sim.raw\n"
+            "  2. Positional argument: y2p plot spec.yaml sim.raw\n"
+            "  3. Add 'raw: sim.raw' to your YAML specification file"
+        )
 
-        # Emit warning if CLI overrides YAML
-        if warning_msg:
-            click.echo(f"Warning: {warning_msg}", err=True)
+    # Emit warning if CLI overrides YAML
+    if warning_msg:
+        click.echo(f"Warning: {warning_msg}", err=True)
 
-        # Apply CLI overrides via helper
-        _apply_overrides(spec, width=width, height=height, title=title, theme=theme)
+    # Apply CLI overrides via helper
+    _apply_overrides(spec, width=width, height=height, title=title, theme=theme)
 
-        # Load plotting data through the shared normalization adapter.
-        if final_raw_file.suffix.lower() == ".csv":
-            click.echo(f"Loading CSV data from: {final_raw_file}")
-        else:
-            click.echo(f"Loading SPICE data from: {final_raw_file}")
+    # Load plotting data through the shared normalization adapter.
+    if final_raw_file.suffix.lower() == ".csv":
+        click.echo(f"Loading CSV data from: {final_raw_file}")
+    else:
+        click.echo(f"Loading SPICE data from: {final_raw_file}")
+    try:
         data = normalize_plot_data(final_raw_file)
+    except FileNotFoundError as exc:
+        raise click.ClickException(f"Input data file not found: {exc}") from exc
+    except (ValueError, TypeError) as exc:
+        raise click.ClickException(f"Failed to load plotting data: {exc}") from exc
 
-        # Create the plot using v1.0.0 API
-        click.echo("Creating plot...")
+    # Create the plot using v1.0.0 API
+    click.echo("Creating plot...")
+    try:
         fig = create_plot(data, spec, show=False)
+    except KeyError as exc:
+        raise click.ClickException(f"Missing signal in plotting data: {exc}") from exc
+    except ValueError as exc:
+        raise click.ClickException(f"Failed to create plot: {exc}") from exc
 
-        if output_file:
-            # Save to file
-            click.echo(f"Saving plot to: {output_file}")
+    if output_file:
+        # Save to file
+        click.echo(f"Saving plot to: {output_file}")
+        try:
             _save_figure(fig, output_file)
-            click.echo("Plot saved successfully!")
-        else:
-            # Display the plot
-            click.echo("Displaying plot...")
-            # Configure renderer based on environment and CLI option
-            configure_plotly_renderer()
-            if renderer != "auto":
-                pio.renderers.default = renderer
-            click.echo(f"Using Plotly renderer: {pio.renderers.default}")
-            fig.show()
-
-    except FileNotFoundError as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
-    except ValueError as e:
-        click.echo(f"Configuration Error: {e}", err=True)
-        sys.exit(1)
-    except Exception as e:
-        click.echo(f"Unexpected Error: {e}", err=True)
-        sys.exit(1)
+        except OSError as exc:
+            raise click.ClickException(
+                f"Failed to save plot to '{output_file}': {exc}"
+            ) from exc
+        click.echo("Plot saved successfully!")
+    else:
+        # Display the plot
+        click.echo("Displaying plot...")
+        # Configure renderer based on environment and CLI option
+        configure_plotly_renderer()
+        if renderer != "auto":
+            pio.renderers.default = renderer
+        click.echo(f"Using Plotly renderer: {pio.renderers.default}")
+        fig.show()
 
 
 @cli.command()
@@ -198,64 +207,61 @@ def init(raw_file: Path):
     init.formatter_class = CustomFormatter
     try:
         dataset = load_spice_raw(raw_file)
-        # Get signals from both coordinates and data variables (coordinates first for x-axis)
-        signals = list(dataset.coords.keys()) + list(dataset.data_vars.keys())
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except (ValueError, TypeError) as exc:
+        raise click.ClickException(f"Failed to load SPICE data: {exc}") from exc
 
-        if not signals:
-            click.echo("Error: No signals found in the raw file.", err=True)
-            sys.exit(1)
+    # Get signals from both coordinates and data variables (coordinates first for x-axis)
+    signals = list(dataset.coords.keys()) + list(dataset.data_vars.keys())
 
-        spec = CommentedMap()
-        spec.yaml_set_comment_before_after_key(
-            "title", before="Plot title (customize as needed)"
-        )
+    if not signals:
+        raise click.ClickException("No signals found in the raw file.")
 
-        spec["raw"] = DoubleQuotedScalarString(raw_file.name)
-        spec["title"] = DoubleQuotedScalarString(f"Analysis of {raw_file.name}")
+    spec = CommentedMap()
+    spec.yaml_set_comment_before_after_key(
+        "title", before="Plot title (customize as needed)"
+    )
 
-        x_comment = """X-axis configuration
+    spec["raw"] = DoubleQuotedScalarString(raw_file.name)
+    spec["title"] = DoubleQuotedScalarString(f"Analysis of {raw_file.name}")
+
+    x_comment = """X-axis configuration
 Independent variable of the simulation, default to the first signal in the raw file
 """
-        spec.yaml_set_comment_before_after_key("x", before=x_comment)
-        x_axis = CommentedMap()
-        x_axis["signal"] = DoubleQuotedScalarString(signals[0])
-        x_axis["label"] = DoubleQuotedScalarString(f"{signals[0]} (s)")
-        spec["x"] = x_axis
+    spec.yaml_set_comment_before_after_key("x", before=x_comment)
+    x_axis = CommentedMap()
+    x_axis["signal"] = DoubleQuotedScalarString(signals[0])
+    x_axis["label"] = DoubleQuotedScalarString(f"{signals[0]} (s)")
+    spec["x"] = x_axis
 
-        y_comment = """Y-axis configuration (add or remove axes as needed)
+    y_comment = """Y-axis configuration (add or remove axes as needed)
 The Y-axis is specified as a list of sub-axes with a synchronized X-axis.
 Even if you have only one Y-axis, you still need to specify it as a list.
 Signal format: <Legend Name>: <Signal Name from Raw File>
 """
-        spec.yaml_set_comment_before_after_key("y", before=y_comment)
-        y_axes = []
-        y_axis = CommentedMap()
-        y_axis["label"] = DoubleQuotedScalarString("Voltage (V)")
+    spec.yaml_set_comment_before_after_key("y", before=y_comment)
+    y_axes = []
+    y_axis = CommentedMap()
+    y_axis["label"] = DoubleQuotedScalarString("Voltage (V)")
 
-        y_signals = CommentedMap()
-        if len(signals) > 1:
-            for sig in signals[1:3]:
-                y_signals[sig] = DoubleQuotedScalarString(sig)
-        y_axis["signals"] = y_signals
-        y_axes.append(y_axis)
-        spec["y"] = y_axes
+    y_signals = CommentedMap()
+    if len(signals) > 1:
+        for sig in signals[1:3]:
+            y_signals[sig] = DoubleQuotedScalarString(sig)
+    y_axis["signals"] = y_signals
+    y_axes.append(y_axis)
+    spec["y"] = y_axes
 
-        dimensions_comment = "Plot height and width in pixels. Remove to use the default (full page width)."
-        spec.yaml_set_comment_before_after_key("height", before=dimensions_comment)
-        spec["height"] = 600
-        spec["width"] = 800
-        spec["show_rangeslider"] = True
+    dimensions_comment = "Plot height and width in pixels. Remove to use the default (full page width)."
+    spec.yaml_set_comment_before_after_key("height", before=dimensions_comment)
+    spec["height"] = 600
+    spec["width"] = 800
+    spec["show_rangeslider"] = True
 
-        yaml = YAML()
-        yaml.indent(mapping=2, sequence=4, offset=2)
-        yaml.dump(spec, sys.stdout)
-
-    except FileNotFoundError as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
-    except Exception as e:
-        click.echo(f"An unexpected error occurred: {e}", err=True)
-        sys.exit(1)
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.dump(spec, sys.stdout)
 
 
 def _save_figure(fig, output_file: Path):
@@ -307,39 +313,39 @@ def signals(raw_file: Path, limit: int, show_all: bool, grep: Optional[str]):
     List available signals in a SPICE raw file.
 
     """
+    click.echo(f"Loading SPICE data from: {raw_file}")
     try:
-        click.echo(f"Loading SPICE data from: {raw_file}")
         dataset = load_spice_raw(raw_file)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except (ValueError, TypeError, RuntimeError) as exc:
+        raise click.ClickException(f"Failed to load SPICE data: {exc}") from exc
 
-        signals = list(dataset.coords.keys()) + list(dataset.data_vars.keys())
+    signals = list(dataset.coords.keys()) + list(dataset.data_vars.keys())
 
-        if grep:
-            import re
+    if grep:
+        import re
 
-            try:
-                original_signals = len(signals)
-                signals = [s for s in signals if re.search(grep, s)]
-                click.echo(
-                    f"\nFound {len(signals)} signals (out of {original_signals} total):"
-                )
-            except re.error as e:
-                raise click.ClickException(f"Invalid regular expression: {e}")
-        else:
-            click.echo(f"\nFound {len(signals)} signals:")
+        try:
+            original_signals = len(signals)
+            signals = [s for s in signals if re.search(grep, s)]
+            click.echo(
+                f"\nFound {len(signals)} signals (out of {original_signals} total):"
+            )
+        except re.error as exc:
+            raise click.ClickException(f"Invalid regular expression: {exc}") from exc
+    else:
+        click.echo(f"\nFound {len(signals)} signals:")
 
-        display_limit = len(signals) if show_all else limit
+    display_limit = len(signals) if show_all else limit
 
-        # Display signals with numbering
-        for i, signal in enumerate(signals[:display_limit], 1):
-            click.echo(f"  {i:2d}. {signal}")
+    # Display signals with numbering
+    for i, signal in enumerate(signals[:display_limit], 1):
+        click.echo(f"  {i:2d}. {signal}")
 
-        if len(signals) > display_limit:
-            click.echo(f"  ... and {len(signals) - display_limit} more signals")
-            click.echo(f"  (Use --limit {len(signals)} or -a to show all)")
-
-    except Exception as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
+    if len(signals) > display_limit:
+        click.echo(f"  ... and {len(signals) - display_limit} more signals")
+        click.echo(f"  (Use --limit {len(signals)} or -a to show all)")
 
 
 signals.epilog = """

--- a/tests/unit/cli/test_cli_basic.py
+++ b/tests/unit/cli/test_cli_basic.py
@@ -72,8 +72,35 @@ class TestSignalsCommand:
     def test_signals_handles_loader_exception(self, tmp_path):
         raw_file = tmp_path / "fail.raw"
         raw_file.write_text("dummy")
-        with patch.object(cli_mod, "load_spice_raw", side_effect=Exception("boom")):
+        with patch.object(cli_mod, "load_spice_raw", side_effect=ValueError("boom")):
             runner = CliRunner()
             result = runner.invoke(cli_mod.cli, ["signals", str(raw_file)])
         assert result.exit_code == 1
-        assert "Error:" in result.output
+        assert "Failed to load SPICE data: boom" in result.output
+
+
+class TestPlotCommandErrorPaths:
+    def test_plot_reports_data_loading_failure(self, tmp_path):
+        spec_file = tmp_path / "spec.yaml"
+        raw_file = tmp_path / "sim.raw"
+        raw_file.touch()
+        spec_file.write_text(
+            f"""
+title: "Test"
+raw: "{raw_file}"
+x:
+  signal: "time"
+y:
+  - label: "Voltage"
+    signals:
+      V1: "v(out)"
+"""
+        )
+
+        with patch.object(cli_mod, "normalize_plot_data", side_effect=ValueError("bad raw file")):
+            runner = CliRunner()
+            result = runner.invoke(cli_mod.cli, ["plot", str(spec_file)])
+
+        assert result.exit_code == 1
+        assert "Configuration Error:" not in result.output
+        assert "Failed to load plotting data: bad raw file" in result.output

--- a/tests/unit/test_package_metadata.py
+++ b/tests/unit/test_package_metadata.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import re
+import importlib
 
+import plotly.io as pio
 import yaml2plot as y2p
 
 
@@ -20,3 +22,14 @@ def test_public_api_exports_csv_helpers() -> None:
     exported = set(y2p.__all__)
     assert "load_csv_data" in exported
     assert "load_csv_data_batch" in exported
+
+
+def test_import_does_not_mutate_plotly_renderer_default() -> None:
+    original = pio.renderers.default
+    try:
+        pio.renderers.default = "json"
+        importlib.reload(y2p)
+        assert pio.renderers.default == "json"
+    finally:
+        pio.renderers.default = original
+        importlib.reload(y2p)


### PR DESCRIPTION
## Summary
- remove import-time Plotly renderer auto-configuration from package initialization
- replace broad CLI catch-all exception handling with typed, actionable Click error paths
- add regression tests for renderer side-effects and CLI data-loading error messaging

## Testing
- ./venv/bin/python -m pytest tests/unit/test_package_metadata.py tests/unit/cli/test_cli_basic.py -v
- ./venv/bin/python -m pytest tests/unit/cli -v
- ./venv/bin/python -m pytest tests/workflows -k "cli or plot" -v
- ./venv/bin/python scripts/lint_tasks_state.py